### PR TITLE
🚨 Fix uncaught exceptions in request middleware

### DIFF
--- a/src/middleware/request-middleware.ts
+++ b/src/middleware/request-middleware.ts
@@ -43,7 +43,7 @@ export const requestMiddleware = (
   }
 
   try {
-    handler(req, res, next);
+    await Promise.resolve(handler(req, res, next));
   } catch (err) {
     if (process.env.NODE_ENV === 'development') {
       logger.log({


### PR DESCRIPTION
While working with your boilerplate I came across a big issue with the request middleware not catching exception to send them to the error handler.

For example try to throw an error in any of the controllers like this:
```typescript
const all: RequestHandler = async (req, res) => {
  throw new Error("Error")
};
```
The server crashes and throws an uncaught exception, this is because the `handler` callback isn't awaited in [request-middleware.ts L46](https://github.com/sidhantpanda/docker-express-typescript-boilerplate/blob/0ed0429a3d8a70d569d0dc3726928e50326f89a4/src/middleware/request-middleware.ts#L46)

To fix this issue we have to add `await` to the `handler` callback and also wrap it in `Promise.Resolve` to convert it into a promise Because `RequestHandler` isn't marked as a `Promise`, even though all the controllers are asynchronous.

This fix works well for both asynchronous and synchronous RequestHandlers.